### PR TITLE
Restricting packages for release-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "plugins": {
       "@release-it-plugins/lerna-changelog": {
         "infile": "CHANGELOG.md",
-        "launchEditor": true
+        "launchEditor": true,
+        "workspaces": ["packages/*"]
       },
       "@release-it-plugins/workspaces": true
     },


### PR DESCRIPTION
## Summary

By default, `@release-it-plugins/workspaces` attempts to use your root package.json's `workspaces` configuration to determine which packages to publish. While it does ignore private packages, it's nicer to just filter out those packages we don't intend to publish ever. This PR updates the configuration to use only those packages under `packages/*`.

 
