### PR TITLE
Adding publish workflow file to allow publishing via actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish Node Packages
+
+on:
+    push:
+        tags:
+            - "v*"
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+            - uses: volta-cli/action@v1
+
+            - name: yarn install
+              run: yarn install --frozen-lockfile
+
+            - name: Build all
+              run: yarn build
+
+            - name: Loop through packages and publish
+              run: |
+                  cd packages
+                  for package in $(ls -d */); do
+                    echo "Publishing $package..."
+                    cd $package
+                    echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+                    npm publish
+                    cd ..
+                  done

--- a/package.json
+++ b/package.json
@@ -1,56 +1,60 @@
 {
-  "version": "2.0.0",
-  "private": true,
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/docusaurus-plugins.git"
-  },
-  "workspaces": [
-    "packages/*",
-    "website"
-  ],
-  "scripts": {
-    "build": "nx run-many --target=build",
-    "clear": "nx run-many --target=clear && nx reset",
-    "start": "cd website && yarn start",
-    "test": "nx run-many --target=test",
-    "watch": "nx run-many --target=watch",
-    "patch": "release-it patch"
-  },
-  "release": {
-    "branches": [
-      "main"
-    ]
-  },
-  "devDependencies": {
-    "@release-it-plugins/lerna-changelog": "^5.0.0",
-    "@release-it-plugins/workspaces": "^3.2.0",
-    "nx": "15.8.7",
-    "release-it": "^15.9.1",
-    "vitest": "^0.29.7"
-  },
-  "volta": {
-    "node": "18.15.0",
-    "yarn": "1.22.19"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org"
-  },
-  "release-it": {
-    "plugins": {
-      "@release-it-plugins/lerna-changelog": {
-        "infile": "CHANGELOG.md",
-        "launchEditor": true,
-        "workspaces": ["packages/*"]
-      },
-      "@release-it-plugins/workspaces": true
+    "version": "2.0.0",
+    "private": true,
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/microsoft/docusaurus-plugins.git"
     },
-    "git": {
-      "tagName": "v${version}"
+    "workspaces": [
+        "packages/*",
+        "website"
+    ],
+    "scripts": {
+        "build": "nx run-many --target=build",
+        "clear": "nx run-many --target=clear && nx reset",
+        "start": "cd website && yarn start",
+        "test": "nx run-many --target=test",
+        "watch": "nx run-many --target=watch",
+        "patch": "release-it patch"
     },
-    "github": {
-      "release": true
+    "release": {
+        "branches": [
+            "main"
+        ]
     },
-    "npm": false
-  }
+    "devDependencies": {
+        "@release-it-plugins/lerna-changelog": "^5.0.0",
+        "@release-it-plugins/workspaces": "^3.2.0",
+        "nx": "15.8.7",
+        "release-it": "^15.9.1",
+        "vitest": "^0.29.7"
+    },
+    "volta": {
+        "node": "18.15.0",
+        "yarn": "1.22.19"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org"
+    },
+    "release-it": {
+        "plugins": {
+            "@release-it-plugins/lerna-changelog": {
+                "infile": "CHANGELOG.md",
+                "launchEditor": true,
+                "workspaces": [
+                    "packages/*"
+                ]
+            },
+            "@release-it-plugins/workspaces": {
+                "publish": false
+            }
+        },
+        "git": {
+            "tagName": "v${version}"
+        },
+        "github": {
+            "release": true
+        },
+        "npm": false
+    }
 }


### PR DESCRIPTION
## Summary

Disables publishing from `@release-it-plugin/workspaces`, instead allowing us to publish via a workflow. This enables us to publish via the `secrets.NPM_TOKEN`, ensuring we don't have to manage secrets locally.
