### PR TITLE
Moves Docusaurus dependencies to devDeps/peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "scripts": {
     "build": "nx run-many --target=build",
     "clear": "nx run-many --target=clear && nx reset",
+    "patch": "release-it patch",
     "start": "cd website && yarn start",
     "test": "nx run-many --target=test",
-    "watch": "nx run-many --target=watch",
-    "patch": "release-it patch"
+    "watch": "nx run-many --target=watch"
   },
   "release": {
     "branches": [

--- a/packages/docusaurus-plugin-application-insights/package.json
+++ b/packages/docusaurus-plugin-application-insights/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@microsoft/applicationinsights-web": "^2.8.9",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "validate-peer-dependencies": "^2.2.0"
   },
   "devDependencies": {
     "@docusaurus/core": "^2.4.0",

--- a/packages/docusaurus-plugin-application-insights/package.json
+++ b/packages/docusaurus-plugin-application-insights/package.json
@@ -24,9 +24,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@docusaurus/core": "^2.4.0",
-    "@docusaurus/types": "^2.4.0",
-    "@docusaurus/utils-validation": "^2.4.0",
     "@microsoft/applicationinsights-web": "^2.8.9",
     "tslib": "^2.5.0"
   },
@@ -34,7 +31,15 @@
     "node": ">=16.14"
   },
   "devDependencies": {
+    "@docusaurus/core": "^2.4.0",
+    "@docusaurus/types": "^2.4.0",
+    "@docusaurus/utils-validation": "^2.4.0",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "@docusaurus/core": ">=2.4.0",
+    "@docusaurus/types": ">=2.4.0",
+    "@docusaurus/utils-validation": ">=2.4.0"
   },
   "files": [
     "lib"

--- a/packages/docusaurus-plugin-application-insights/package.json
+++ b/packages/docusaurus-plugin-application-insights/package.json
@@ -2,33 +2,30 @@
   "name": "@rise4fun/docusaurus-plugin-application-insights",
   "version": "2.1.3",
   "description": "Microsoft Application Insights plugin for Docusaurus.",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
   "keywords": [
     "Docusaurus",
     "rise4fun"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "clear": "rm -Rf lib",
-    "build": "tsc --build",
-    "test": "vitest run",
-    "watch": "tsc --build --watch"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/docusaurus-plugins.git",
     "directory": "packages/docusaurus-plugin-application-insights"
   },
   "license": "MIT",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "clear": "rm -Rf lib",
+    "test": "vitest run",
+    "watch": "tsc --build --watch"
+  },
   "dependencies": {
     "@microsoft/applicationinsights-web": "^2.8.9",
     "tslib": "^2.5.0"
-  },
-  "engines": {
-    "node": ">=16.14"
   },
   "devDependencies": {
     "@docusaurus/core": "^2.4.0",
@@ -41,7 +38,10 @@
     "@docusaurus/types": ">=2.4.0",
     "@docusaurus/utils-validation": ">=2.4.0"
   },
-  "files": [
-    "lib"
-  ]
+  "engines": {
+    "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/docusaurus-plugin-application-insights/src/index.ts
+++ b/packages/docusaurus-plugin-application-insights/src/index.ts
@@ -2,6 +2,9 @@ import { Joi } from '@docusaurus/utils-validation';
 import type { LoadContext, Plugin, OptionValidationContext } from '@docusaurus/types';
 import type { ApplicationInsightsOptions, PluginOptions } from './options';
 import { resolve } from 'node:path';
+import validatePeerDependencies from 'validate-peer-dependencies';
+
+validatePeerDependencies(__dirname);
 
 export default function pluginApplicationInsights(
   _context: LoadContext,

--- a/packages/docusaurus-plugin-rise4fun/package.json
+++ b/packages/docusaurus-plugin-rise4fun/package.json
@@ -19,11 +19,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@docusaurus/core": "^2.4.0",
-    "@docusaurus/remark-plugin-npm2yarn": "^2.4.0",
-    "@docusaurus/theme-mermaid": "^2.4.0",
-    "@docusaurus/types": "^2.4.0",
-    "@docusaurus/utils-validation": "^2.4.0",
     "@rise4fun/docusaurus-plugin-application-insights": "^2.1.3",
     "@rise4fun/docusaurus-remark-plugin-code-element": "^2.1.3",
     "@rise4fun/docusaurus-remark-plugin-code-tabs": "^2.1.3",
@@ -42,6 +37,18 @@
     "node": ">=16.14"
   },
   "devDependencies": {
+    "@docusaurus/core": "^2.4.0",
+    "@docusaurus/remark-plugin-npm2yarn": "^2.4.0",
+    "@docusaurus/theme-mermaid": "^2.4.0",
+    "@docusaurus/types": "^2.4.0",
+    "@docusaurus/utils-validation": "^2.4.0",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "@docusaurus/core": ">=2.4.0",
+    "@docusaurus/remark-plugin-npm2yarn": ">=2.4.0",
+    "@docusaurus/theme-mermaid": ">=2.4.0",
+    "@docusaurus/types": ">=2.4.0",
+    "@docusaurus/utils-validation": ">=2.4.0"
   }
 }

--- a/packages/docusaurus-plugin-rise4fun/package.json
+++ b/packages/docusaurus-plugin-rise4fun/package.json
@@ -28,7 +28,8 @@
     "hast-util-is-element": "1.1.0",
     "rehype-katex": "5",
     "remark-math": "3",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "validate-peer-dependencies": "^2.2.0"
   },
   "devDependencies": {
     "@docusaurus/core": "^2.4.0",

--- a/packages/docusaurus-plugin-rise4fun/package.json
+++ b/packages/docusaurus-plugin-rise4fun/package.json
@@ -2,29 +2,26 @@
   "name": "@rise4fun/docusaurus-plugin-rise4fun",
   "version": "2.1.3",
   "description": "Docusaurus plugin for Microsoft projects.",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "clear": "rm -Rf lib",
-    "build": "tsc --build && node ../../admin/scripts/copyUntypedFiles.mjs",
-    "watch": "tsc --build --watch"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/docusaurus-plugins.git",
     "directory": "packages/docusaurus-plugin-rise4fun"
   },
   "license": "MIT",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc --build && node ../../admin/scripts/copyUntypedFiles.mjs",
+    "clear": "rm -Rf lib",
+    "watch": "tsc --build --watch"
+  },
   "dependencies": {
     "@rise4fun/docusaurus-plugin-application-insights": "^2.1.3",
     "@rise4fun/docusaurus-remark-plugin-code-element": "^2.1.3",
     "@rise4fun/docusaurus-remark-plugin-code-tabs": "^2.1.3",
     "@rise4fun/docusaurus-remark-plugin-compile-code": "^2.1.3",
-    "@rise4fun/docusaurus-remark-plugin-side-editor": "^2.1.3",
     "@rise4fun/docusaurus-remark-plugin-import-file": "^2.1.3",
+    "@rise4fun/docusaurus-remark-plugin-side-editor": "^2.1.3",
     "@rise4fun/docusaurus-theme-codesandbox-button": "^2.1.3",
     "@rise4fun/docusaurus-theme-side-editor": "^2.1.3",
     "fs-extra": "^11.1.0",
@@ -32,9 +29,6 @@
     "rehype-katex": "5",
     "remark-math": "3",
     "tslib": "^2.5.0"
-  },
-  "engines": {
-    "node": ">=16.14"
   },
   "devDependencies": {
     "@docusaurus/core": "^2.4.0",
@@ -50,5 +44,11 @@
     "@docusaurus/theme-mermaid": ">=2.4.0",
     "@docusaurus/types": ">=2.4.0",
     "@docusaurus/utils-validation": ">=2.4.0"
+  },
+  "engines": {
+    "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-plugin-rise4fun/src/index.ts
+++ b/packages/docusaurus-plugin-rise4fun/src/index.ts
@@ -10,6 +10,9 @@ import codeElementPlugin from '@rise4fun/docusaurus-remark-plugin-code-element';
 import sideEditorPlugin from '@rise4fun/docusaurus-remark-plugin-side-editor';
 import { join, resolve } from 'node:path';
 import { ensureDirSync, writeJSONSync } from 'fs-extra';
+import validatePeerDependencies from 'validate-peer-dependencies';
+
+validatePeerDependencies(__dirname);
 
 const mathPlugin = require('remark-math');
 const katexPlugin = require('rehype-katex');

--- a/packages/docusaurus-remark-plugin-code-element/package.json
+++ b/packages/docusaurus-remark-plugin-code-element/package.json
@@ -2,28 +2,25 @@
   "name": "@rise4fun/docusaurus-remark-plugin-code-element",
   "version": "2.1.3",
   "description": "Run tool and show output.",
-  "main": "lib/index.js",
-  "types": "src/types.d.ts",
   "keywords": [
     "Docusaurus",
     "remark-plugin",
     "rise4fun"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "clear": "rm -Rf lib && rm -Rf .docusaurus",
-    "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/docusaurus-plugins.git",
     "directory": "packages/docusaurus-remark-plugin-code-element"
   },
   "license": "MIT",
+  "main": "lib/index.js",
+  "types": "src/types.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clear": "rm -Rf lib && rm -Rf .docusaurus",
+    "test": "vitest run",
+    "watch": "tsc --watch"
+  },
   "dependencies": {
     "fs-extra": "^11.1.0",
     "minimatch": "^6.1.6",
@@ -41,5 +38,8 @@
   },
   "engines": {
     "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-remark-plugin-code-tabs/package.json
+++ b/packages/docusaurus-remark-plugin-code-tabs/package.json
@@ -2,28 +2,25 @@
   "name": "@rise4fun/docusaurus-remark-plugin-code-tabs",
   "version": "2.1.3",
   "description": "Remark docusaurus plugin that assembles code sections in tabs.",
-  "main": "lib/index.js",
-  "types": "src/types.d.ts",
   "keywords": [
     "Docusaurus",
     "remark-plugin",
     "rise4fun"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "clear": "rm -Rf lib && rm -Rf .docusaurus",
-    "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/docusaurus-plugins.git",
     "directory": "packages/docusaurus-remark-plugin-code-tabs"
   },
   "license": "MIT",
+  "main": "lib/index.js",
+  "types": "src/types.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clear": "rm -Rf lib && rm -Rf .docusaurus",
+    "test": "vitest run",
+    "watch": "tsc --watch"
+  },
   "dependencies": {
     "fs-extra": "^11.1.0",
     "p-all": "^4.0.0",
@@ -40,5 +37,8 @@
   },
   "engines": {
     "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-remark-plugin-compile-code/package.json
+++ b/packages/docusaurus-remark-plugin-compile-code/package.json
@@ -2,46 +2,46 @@
   "name": "@rise4fun/docusaurus-remark-plugin-compile-code",
   "version": "2.1.3",
   "description": "Run tool and show output.",
-  "main": "lib/index.js",
-  "types": "src/types.d.ts",
   "keywords": [
     "Docusaurus",
     "remark-plugin",
     "rise4fun"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "clear": "rm -Rf lib && rm -Rf .docusaurus",
-    "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/docusaurus-plugins.git",
     "directory": "packages/docusaurus-remark-plugin-compile-code"
   },
   "license": "MIT",
+  "main": "lib/index.js",
+  "types": "src/types.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clear": "rm -Rf lib && rm -Rf .docusaurus",
+    "test": "vitest run",
+    "watch": "tsc --watch"
+  },
   "dependencies": {
     "fs-extra": "^11.1.0",
     "minimatch": "^6.1.6",
     "p-all": "^4.0.0",
+    "puppeteer": "^19.6.3",
     "tslib": "^2.4.0",
     "typescript": "^4.9.4",
-    "unist-util-visit": "^2.0.3",
-    "puppeteer": "^19.6.3"
+    "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.0",
     "@types/mdast": "^3.0.10",
+    "@types/puppeteer": "^7.0.4",
     "remark": "^12.0.1",
     "remark-mdx": "^1.6.21",
-    "to-vfile": "^6.1.0",
-    "@types/puppeteer": "^7.0.4"
+    "to-vfile": "^6.1.0"
   },
   "engines": {
     "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-remark-plugin-import-file/package.json
+++ b/packages/docusaurus-remark-plugin-import-file/package.json
@@ -2,28 +2,25 @@
   "name": "@rise4fun/docusaurus-remark-plugin-import-file",
   "version": "2.1.3",
   "description": "Import markdown file",
-  "main": "lib/index.js",
-  "types": "src/types.d.ts",
   "keywords": [
     "Docusaurus",
     "remark-plugin",
     "rise4fun"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "clear": "rm -Rf lib && rm -Rf .docusaurus",
-    "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/docusaurus-plugins.git",
     "directory": "packages/docusaurus-remark-plugin-import-file"
   },
   "license": "MIT",
+  "main": "lib/index.js",
+  "types": "src/types.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clear": "rm -Rf lib && rm -Rf .docusaurus",
+    "test": "vitest run",
+    "watch": "tsc --watch"
+  },
   "dependencies": {
     "fs-extra": "^11.1.0",
     "minimatch": "^6.1.6",
@@ -41,5 +38,8 @@
   },
   "engines": {
     "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-remark-plugin-side-editor/package.json
+++ b/packages/docusaurus-remark-plugin-side-editor/package.json
@@ -2,28 +2,25 @@
   "name": "@rise4fun/docusaurus-remark-plugin-side-editor",
   "version": "2.1.3",
   "description": "Remark docusaurus plugin that assembles code sections in tabs.",
-  "main": "lib/index.js",
-  "types": "src/types.d.ts",
   "keywords": [
     "Docusaurus",
     "remark-plugin",
     "rise4fun"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "clear": "rm -Rf lib && rm -Rf .docusaurus",
-    "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/docusaurus-plugins.git",
     "directory": "packages/docusaurus-remark-plugin-side-editor"
   },
   "license": "MIT",
+  "main": "lib/index.js",
+  "types": "src/types.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clear": "rm -Rf lib && rm -Rf .docusaurus",
+    "test": "vitest run",
+    "watch": "tsc --watch"
+  },
   "dependencies": {
     "fs-extra": "^11.1.0",
     "p-all": "^4.0.0",
@@ -40,5 +37,8 @@
   },
   "engines": {
     "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-theme-codesandbox-button/package.json
+++ b/packages/docusaurus-theme-codesandbox-button/package.json
@@ -37,17 +37,20 @@
     "clear": "rm -Rf ./lib"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.4.0",
-    "@docusaurus/types": "^2.4.0",
-    "@docusaurus/utils-validation": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
+    "@docusaurus/core": "^2.4.0",
+    "@docusaurus/types": "^2.4.0",
+    "@docusaurus/utils-validation": "^2.4.0",
     "@types/mdx-js__react": "^1.5.5"
   },
   "peerDependencies": {
+    "@docusaurus/core": ">=2.4.0",
+    "@docusaurus/types": ">=2.4.0",
+    "@docusaurus/utils-validation": ">=2.4.0",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-codesandbox-button/package.json
+++ b/packages/docusaurus-theme-codesandbox-button/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "validate-peer-dependencies": "^2.2.0"
   },
   "devDependencies": {
     "@docusaurus/core": "^2.4.0",

--- a/packages/docusaurus-theme-codesandbox-button/package.json
+++ b/packages/docusaurus-theme-codesandbox-button/package.json
@@ -2,12 +2,16 @@
   "name": "@rise4fun/docusaurus-theme-codesandbox-button",
   "version": "2.1.3",
   "description": "CodeSandbox components for Docusaurus.",
-  "main": "lib/index.js",
-  "types": "src/theme-codesandbox-button.d.ts",
   "keywords": [
     "Docusaurus",
     "rise4fun"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/docusaurus-plugins.git",
+    "directory": "packages/docusaurus-theme-codesandbox-button"
+  },
+  "license": "MIT",
   "sideEffects": false,
   "exports": {
     "./lib/*": "./lib/*",
@@ -21,20 +25,13 @@
       "default": "./lib/index.js"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/docusaurus-plugins.git",
-    "directory": "packages/docusaurus-theme-codesandbox-button"
-  },
-  "license": "MIT",
+  "main": "lib/index.js",
+  "types": "src/theme-codesandbox-button.d.ts",
   "scripts": {
     "build": "tsc --build && node ../../admin/scripts/copyUntypedFiles.mjs",
-    "watch": "run-p -c copy:watch build:watch",
     "build:watch": "tsc --build --watch",
-    "clear": "rm -Rf ./lib"
+    "clear": "rm -Rf ./lib",
+    "watch": "run-p -c copy:watch build:watch"
   },
   "dependencies": {
     "@mdx-js/react": "^1.6.22",
@@ -56,5 +53,8 @@
   },
   "engines": {
     "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-theme-codesandbox-button/src/index.ts
+++ b/packages/docusaurus-theme-codesandbox-button/src/index.ts
@@ -3,6 +3,9 @@ import type {
   ThemeConfig,
   CodeSandboxButtonThemeConfig,
 } from '@rise4fun/docusaurus-theme-codesandbox-button';
+import validatePeerDependencies from 'validate-peer-dependencies';
+
+validatePeerDependencies(__dirname);
 
 export default function themeCodeSandboxButton(): Plugin<void> {
   return {

--- a/packages/docusaurus-theme-side-editor/package.json
+++ b/packages/docusaurus-theme-side-editor/package.json
@@ -40,7 +40,8 @@
     "clsx": "^1.2.1",
     "monaco-editor": "^0.34.1",
     "react-resizable-panels": "^0.0.36",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "validate-peer-dependencies": "^2.2.0"
   },
   "devDependencies": {
     "@docusaurus/core": "^2.4.0",

--- a/packages/docusaurus-theme-side-editor/package.json
+++ b/packages/docusaurus-theme-side-editor/package.json
@@ -38,9 +38,6 @@
     "clear": "rm -Rf ./lib"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.4.0",
-    "@docusaurus/types": "^2.4.0",
-    "@docusaurus/utils-validation": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
     "@monaco-editor/react": "^4.4.6",
     "clsx": "^1.2.1",
@@ -49,9 +46,15 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
+    "@docusaurus/core": "^2.4.0",
+    "@docusaurus/types": "^2.4.0",
+    "@docusaurus/utils-validation": "^2.4.0",
     "@types/mdx-js__react": "^1.5.5"
   },
   "peerDependencies": {
+    "@docusaurus/core": ">=2.4.0",
+    "@docusaurus/types": ">=2.4.0",
+    "@docusaurus/utils-validation": ">=2.4.0",
     "react": "^16.8.4 || ^17.0.0",
     "react-dom": "^16.8.4 || ^17.0.0"
   },

--- a/packages/docusaurus-theme-side-editor/package.json
+++ b/packages/docusaurus-theme-side-editor/package.json
@@ -2,12 +2,16 @@
   "name": "@rise4fun/docusaurus-theme-side-editor",
   "version": "2.1.3",
   "description": "Side editor components for Docusaurus.",
-  "main": "lib/index.js",
-  "types": "src/theme-side-editor.d.ts",
   "keywords": [
     "Docusaurus",
     "rise4fun"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/docusaurus-plugins.git",
+    "directory": "packages/docusaurus-theme-side-editor"
+  },
+  "license": "MIT",
   "sideEffects": false,
   "exports": {
     "./lib/*": "./lib/*",
@@ -21,21 +25,14 @@
       "default": "./lib/index.js"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/docusaurus-plugins.git",
-    "directory": "packages/docusaurus-theme-side-editor"
-  },
-  "license": "MIT",
+  "main": "lib/index.js",
+  "types": "src/theme-side-editor.d.ts",
   "scripts": {
     "build": "tsc --build && node ../../admin/scripts/copyUntypedFiles.mjs",
-    "watch": "run-p -c copy:watch build:watch",
     "build:watch": "tsc --build --watch",
+    "clear": "rm -Rf ./lib",
     "copy:watch": "node ../../admin/scripts/copyUntypedFiles.mjs --watch",
-    "clear": "rm -Rf ./lib"
+    "watch": "run-p -c copy:watch build:watch"
   },
   "dependencies": {
     "@mdx-js/react": "^1.6.22",
@@ -60,5 +57,8 @@
   },
   "engines": {
     "node": ">=16.14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docusaurus-theme-side-editor/src/index.ts
+++ b/packages/docusaurus-theme-side-editor/src/index.ts
@@ -1,5 +1,8 @@
 import type { Plugin } from '@docusaurus/types';
 import type { ThemeConfig, SideEditorThemeConfig } from '@rise4fun/docusaurus-theme-side-editor';
+import validatePeerDependencies from 'validate-peer-dependencies';
+
+validatePeerDependencies(__dirname);
 
 export default function themeSideEditor(): Plugin<void> {
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11694,7 +11694,7 @@ validate-peer-dependencies@^1.0.0:
     resolve-package-path "^3.1.0"
     semver "^7.3.2"
 
-validate-peer-dependencies@^2.0.0:
+validate-peer-dependencies@^2.0.0, validate-peer-dependencies@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz#47b8ff008f66a66fc5d8699123844522c1d874f4"
   integrity sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==


### PR DESCRIPTION
## Summary

Moves Docusaurus dependencies to devDeps/peerDeps. This allows the host Docusaurus site to provide the dependency versions directly, rather than them being pulled in transitively.

Also runs `npx sort-package-json` on all package.json files.
