### PR TITLE
Renames packages to republish under @microsoft scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Rise4fun Docusaurus plugins
+# Microsoft Docusaurus plugins
 
-This repository contains plugins for Docusaurus to support creating rich documentation for programming languages tools.
+This repository contains plugins for Docusaurus, including but not limited to support for creating rich documentation for programming languages tools.
 
 - [Read the documentation](https://microsoft.github.io/docusaurus-plugins).
 

--- a/packages/docusaurus-plugin-application-insights/README.md
+++ b/packages/docusaurus-plugin-application-insights/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-plugin-application-insights`
+# `@microsoft/docusaurus-plugin-application-insights`
 
-Docusaurus plugin to support Microsoft Application Insights ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-plugin-application-insights)).
+Docusaurus plugin to support Microsoft Application Insights ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-plugin-application-insights)).
 
 ## Usage
 

--- a/packages/docusaurus-plugin-application-insights/package.json
+++ b/packages/docusaurus-plugin-application-insights/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-plugin-application-insights",
+  "name": "@microsoft/docusaurus-plugin-application-insights",
   "version": "3.0.0",
   "description": "Microsoft Application Insights plugin for Docusaurus.",
   "keywords": [

--- a/packages/docusaurus-plugin-application-insights/src/index.ts
+++ b/packages/docusaurus-plugin-application-insights/src/index.ts
@@ -12,7 +12,7 @@ export default function pluginApplicationInsights(
 ): Plugin {
   const isProd = process.env.NODE_ENV === 'production';
   return {
-    name: '@rise4fun/docusaurus-plugin-application-insights',
+    name: '@microsoft/docusaurus-plugin-application-insights',
 
     getClientModules() {
       return isProd ? [resolve(__dirname, './analytics')] : [];

--- a/packages/docusaurus-plugin-rise4fun/README.md
+++ b/packages/docusaurus-plugin-rise4fun/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-plugins`
+# `@microsoft/docusaurus-plugins`
 
-Docusaurus plugin for Microsoft Research Rise4fun web sites ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-plugin-rise4fun)).
+Docusaurus plugin for Microsoft Research Rise4fun web sites ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-plugin-rise4fun)).
 
 ## Usage
 

--- a/packages/docusaurus-plugin-rise4fun/package.json
+++ b/packages/docusaurus-plugin-rise4fun/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-plugin-rise4fun",
+  "name": "@microsoft/docusaurus-plugin-rise4fun",
   "version": "3.0.0",
   "description": "Docusaurus plugin for Microsoft projects.",
   "repository": {
@@ -16,14 +16,14 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@rise4fun/docusaurus-plugin-application-insights": "^3.0.0",
-    "@rise4fun/docusaurus-remark-plugin-code-element": "^3.0.0",
-    "@rise4fun/docusaurus-remark-plugin-code-tabs": "^3.0.0",
-    "@rise4fun/docusaurus-remark-plugin-compile-code": "^3.0.0",
-    "@rise4fun/docusaurus-remark-plugin-import-file": "^3.0.0",
-    "@rise4fun/docusaurus-remark-plugin-side-editor": "^3.0.0",
-    "@rise4fun/docusaurus-theme-codesandbox-button": "^3.0.0",
-    "@rise4fun/docusaurus-theme-side-editor": "^3.0.0",
+    "@microsoft/docusaurus-plugin-application-insights": "^3.0.0",
+    "@microsoft/docusaurus-remark-plugin-code-element": "^3.0.0",
+    "@microsoft/docusaurus-remark-plugin-code-tabs": "^3.0.0",
+    "@microsoft/docusaurus-remark-plugin-compile-code": "^3.0.0",
+    "@microsoft/docusaurus-remark-plugin-import-file": "^3.0.0",
+    "@microsoft/docusaurus-remark-plugin-side-editor": "^3.0.0",
+    "@microsoft/docusaurus-theme-codesandbox-button": "^3.0.0",
+    "@microsoft/docusaurus-theme-side-editor": "^3.0.0",
     "fs-extra": "^11.1.0",
     "hast-util-is-element": "1.1.0",
     "rehype-katex": "5",

--- a/packages/docusaurus-plugin-rise4fun/src/index.ts
+++ b/packages/docusaurus-plugin-rise4fun/src/index.ts
@@ -1,13 +1,13 @@
 import type { Config, ThemeConfig } from '@docusaurus/types';
 import type { PluginOptions, Options } from './options';
-import appInsightPlugin from '@rise4fun/docusaurus-plugin-application-insights';
+import appInsightPlugin from '@microsoft/docusaurus-plugin-application-insights';
 import npm2yarnPlugin from '@docusaurus/remark-plugin-npm2yarn';
 import compileCodePlugin, {
   ToolLangOptions,
-} from '@rise4fun/docusaurus-remark-plugin-compile-code';
-import codeTabsPlugin from '@rise4fun/docusaurus-remark-plugin-code-tabs';
-import codeElementPlugin from '@rise4fun/docusaurus-remark-plugin-code-element';
-import sideEditorPlugin from '@rise4fun/docusaurus-remark-plugin-side-editor';
+} from '@microsoft/docusaurus-remark-plugin-compile-code';
+import codeTabsPlugin from '@microsoft/docusaurus-remark-plugin-code-tabs';
+import codeElementPlugin from '@microsoft/docusaurus-remark-plugin-code-element';
+import sideEditorPlugin from '@microsoft/docusaurus-remark-plugin-side-editor';
 import { join, resolve } from 'node:path';
 import { ensureDirSync, writeJSONSync } from 'fs-extra';
 import validatePeerDependencies from 'validate-peer-dependencies';
@@ -16,7 +16,7 @@ validatePeerDependencies(__dirname);
 
 const mathPlugin = require('remark-math');
 const katexPlugin = require('rehype-katex');
-const importFilePlugin = require('@rise4fun/docusaurus-remark-plugin-import-file');
+const importFilePlugin = require('@microsoft/docusaurus-remark-plugin-import-file');
 
 const repo = process.env.GITHUB_REPOSITORY;
 
@@ -138,14 +138,14 @@ export async function configure(
   }
 
   if (codeSandbox !== false) {
-    injectTheme('@rise4fun/docusaurus-theme-codesandbox-button', codeSandbox);
+    injectTheme('@microsoft/docusaurus-theme-codesandbox-button', codeSandbox);
     if (!themeConfig.codeSandbox) themeConfig.codeSandbox = codeSandbox;
   }
 
   // copy over side editor
   if (!themeConfig.sideEditor) themeConfig.sideEditor = sideEditor;
   if (themeConfig.sideEditor) {
-    injectTheme('@rise4fun/docusaurus-theme-side-editor', themeConfig.sideEditor);
+    injectTheme('@microsoft/docusaurus-theme-side-editor', themeConfig.sideEditor);
     injectBeforeDefaultRemarkPlugin(sideEditorPlugin, themeConfig.sideEditor);
   }
 

--- a/packages/docusaurus-plugin-rise4fun/src/options.ts
+++ b/packages/docusaurus-plugin-rise4fun/src/options.ts
@@ -1,11 +1,11 @@
-import type { PluginOptions as ApplicationInsightsOptions } from '@rise4fun/docusaurus-plugin-application-insights';
-import type { PluginOptions as CompileCodePluginOptions } from '@rise4fun/docusaurus-remark-plugin-compile-code';
-import type { PluginOptions as CodeTabsPluginOptions } from '@rise4fun/docusaurus-remark-plugin-code-tabs';
-import type { PluginOptions as CodeElementPluginOptions } from '@rise4fun/docusaurus-remark-plugin-code-element';
-import type { PluginOptions as SideEditorRemarkPluginOptions } from '@rise4fun/docusaurus-remark-plugin-side-editor';
-import type { SideEditorThemeConfig } from '@rise4fun/docusaurus-theme-side-editor';
-import type { CodeSandboxButtonThemeConfig } from '@rise4fun/docusaurus-theme-codesandbox-button';
-import type { PluginOptions as ImportFilePluginOptions } from '@rise4fun/docusaurus-remark-plugin-import-file';
+import type { PluginOptions as ApplicationInsightsOptions } from '@microsoft/docusaurus-plugin-application-insights';
+import type { PluginOptions as CompileCodePluginOptions } from '@microsoft/docusaurus-remark-plugin-compile-code';
+import type { PluginOptions as CodeTabsPluginOptions } from '@microsoft/docusaurus-remark-plugin-code-tabs';
+import type { PluginOptions as CodeElementPluginOptions } from '@microsoft/docusaurus-remark-plugin-code-element';
+import type { PluginOptions as SideEditorRemarkPluginOptions } from '@microsoft/docusaurus-remark-plugin-side-editor';
+import type { SideEditorThemeConfig } from '@microsoft/docusaurus-theme-side-editor';
+import type { CodeSandboxButtonThemeConfig } from '@microsoft/docusaurus-theme-codesandbox-button';
+import type { PluginOptions as ImportFilePluginOptions } from '@microsoft/docusaurus-remark-plugin-import-file';
 
 export interface AlgoliaOptions {
   /**

--- a/packages/docusaurus-remark-plugin-code-element/README.md
+++ b/packages/docusaurus-remark-plugin-code-element/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-remark-plugin-code-element`
+# `@microsoft/docusaurus-remark-plugin-code-element`
 
-Docusaurus plugin to convert fenced code section into MDX snippets ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-remark-plugin-code-element)).
+Docusaurus plugin to convert fenced code section into MDX snippets ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-remark-plugin-code-element)).
 
 ## Usage
 

--- a/packages/docusaurus-remark-plugin-code-element/package.json
+++ b/packages/docusaurus-remark-plugin-code-element/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-remark-plugin-code-element",
+  "name": "@microsoft/docusaurus-remark-plugin-code-element",
   "version": "3.0.0",
   "description": "Run tool and show output.",
   "keywords": [

--- a/packages/docusaurus-remark-plugin-code-tabs/README.md
+++ b/packages/docusaurus-remark-plugin-code-tabs/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-remark-plugin-code-tabs`
+# `@microsoft/docusaurus-remark-plugin-code-tabs`
 
-Docusaurus remark plugin that assembles code sections into tabs, with optional CodeSandbox button ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-remark-plugin-code-tabs)).
+Docusaurus remark plugin that assembles code sections into tabs, with optional CodeSandbox button ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-remark-plugin-code-tabs)).
 
 ## Usage
 

--- a/packages/docusaurus-remark-plugin-code-tabs/package.json
+++ b/packages/docusaurus-remark-plugin-code-tabs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-remark-plugin-code-tabs",
+  "name": "@microsoft/docusaurus-remark-plugin-code-tabs",
   "version": "3.0.0",
   "description": "Remark docusaurus plugin that assembles code sections in tabs.",
   "keywords": [

--- a/packages/docusaurus-remark-plugin-compile-code/README.md
+++ b/packages/docusaurus-remark-plugin-compile-code/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-remark-plugin-compile-code`
+# `@microsoft/docusaurus-remark-plugin-compile-code`
 
-Docusaurus plugin to run a tool against code snippets at build time ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-remark-plugin-compile-code)).
+Docusaurus plugin to run a tool against code snippets at build time ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-remark-plugin-compile-code)).
 
 ## Usage
 

--- a/packages/docusaurus-remark-plugin-compile-code/package.json
+++ b/packages/docusaurus-remark-plugin-compile-code/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-remark-plugin-compile-code",
+  "name": "@microsoft/docusaurus-remark-plugin-compile-code",
   "version": "3.0.0",
   "description": "Run tool and show output.",
   "keywords": [

--- a/packages/docusaurus-remark-plugin-import-file/README.md
+++ b/packages/docusaurus-remark-plugin-import-file/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-remark-plugin-import-file`
+# `@microsoft/docusaurus-remark-plugin-import-file`
 
-Docusaurus plugin to import markdown files ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-remark-plugin-import-files)).
+Docusaurus plugin to import markdown files ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-remark-plugin-import-files)).
 
 ## Usage
 

--- a/packages/docusaurus-remark-plugin-import-file/package.json
+++ b/packages/docusaurus-remark-plugin-import-file/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-remark-plugin-import-file",
+  "name": "@microsoft/docusaurus-remark-plugin-import-file",
   "version": "3.0.0",
   "description": "Import markdown file",
   "keywords": [

--- a/packages/docusaurus-remark-plugin-side-editor/README.md
+++ b/packages/docusaurus-remark-plugin-side-editor/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-remark-plugin-side-editor`
+# `@microsoft/docusaurus-remark-plugin-side-editor`
 
-Docusaurus remark plugin that injects `Edit` button after code section that open snippet in side editor ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-theme-side-editor)).
+Docusaurus remark plugin that injects `Edit` button after code section that open snippet in side editor ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-theme-side-editor)).
 
 ## Usage
 

--- a/packages/docusaurus-remark-plugin-side-editor/package.json
+++ b/packages/docusaurus-remark-plugin-side-editor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-remark-plugin-side-editor",
+  "name": "@microsoft/docusaurus-remark-plugin-side-editor",
   "version": "3.0.0",
   "description": "Remark docusaurus plugin that assembles code sections in tabs.",
   "keywords": [

--- a/packages/docusaurus-theme-codesandbox-button/README.md
+++ b/packages/docusaurus-theme-codesandbox-button/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-theme-codesandbox-button`
+# `@microsoft/docusaurus-theme-codesandbox-button`
 
-Docusaurus theme component that displays a button to create/open a CodeSandbox project ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-theme-codesandbox-button)).
+Docusaurus theme component that displays a button to create/open a CodeSandbox project ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-theme-codesandbox-button)).
 
 ![Demo of the feature in Docusaurus](./demo.png)
 

--- a/packages/docusaurus-theme-codesandbox-button/package.json
+++ b/packages/docusaurus-theme-codesandbox-button/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-theme-codesandbox-button",
+  "name": "@microsoft/docusaurus-theme-codesandbox-button",
   "version": "3.0.0",
   "description": "CodeSandbox components for Docusaurus.",
   "keywords": [

--- a/packages/docusaurus-theme-codesandbox-button/src/index.ts
+++ b/packages/docusaurus-theme-codesandbox-button/src/index.ts
@@ -2,14 +2,14 @@ import type { Plugin } from '@docusaurus/types';
 import type {
   ThemeConfig,
   CodeSandboxButtonThemeConfig,
-} from '@rise4fun/docusaurus-theme-codesandbox-button';
+} from '@microsoft/docusaurus-theme-codesandbox-button';
 import validatePeerDependencies from 'validate-peer-dependencies';
 
 validatePeerDependencies(__dirname);
 
 export default function themeCodeSandboxButton(): Plugin<void> {
   return {
-    name: '@rise4fun/docusaurus-theme-codesandbox-button',
+    name: '@microsoft/docusaurus-theme-codesandbox-button',
 
     getThemePath() {
       return '../lib/theme';

--- a/packages/docusaurus-theme-codesandbox-button/src/theme-codesandbox-button.ts
+++ b/packages/docusaurus-theme-codesandbox-button/src/theme-codesandbox-button.ts
@@ -1,6 +1,6 @@
 /// <reference types="@docusaurus/module-type-aliases" />
 
-declare module '@rise4fun/docusaurus-theme-codesandbox-button' {
+declare module '@microsoft/docusaurus-theme-codesandbox-button' {
   export interface CodeSandboxFileOptions {
     content: string | object;
   }

--- a/packages/docusaurus-theme-codesandbox-button/src/theme/CodeSandboxButton/index.tsx
+++ b/packages/docusaurus-theme-codesandbox-button/src/theme/CodeSandboxButton/index.tsx
@@ -6,7 +6,7 @@ import styles from './styles.module.css';
 import type {
   CodeSandboxOptions,
   ThemeConfig,
-} from '@rise4fun/docusaurus-theme-codesandbox-button';
+} from '@microsoft/docusaurus-theme-codesandbox-button';
 
 const DEFAULT_CODESANDBOX: CodeSandboxOptions = {
   files: {

--- a/packages/docusaurus-theme-side-editor/README.md
+++ b/packages/docusaurus-theme-side-editor/README.md
@@ -1,6 +1,6 @@
-# `@rise4fun/docusaurus-theme-side-editor`
+# `@microsoft/docusaurus-theme-side-editor`
 
-A Docusaurus theme component that creates a side editor ([npm.js](https://www.npmjs.com/package/@rise4fun/docusaurus-theme-side-editor)).
+A Docusaurus theme component that creates a side editor ([npm.js](https://www.npmjs.com/package/@microsoft/docusaurus-theme-side-editor)).
 
 ## Usage
 

--- a/packages/docusaurus-theme-side-editor/package.json
+++ b/packages/docusaurus-theme-side-editor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rise4fun/docusaurus-theme-side-editor",
+  "name": "@microsoft/docusaurus-theme-side-editor",
   "version": "3.0.0",
   "description": "Side editor components for Docusaurus.",
   "keywords": [

--- a/packages/docusaurus-theme-side-editor/src/client/SideEditorContext.tsx
+++ b/packages/docusaurus-theme-side-editor/src/client/SideEditorContext.tsx
@@ -1,6 +1,6 @@
 import SideEditorRoot from '@theme/SideEditorRoot';
 import React, { createContext, ReactNode, useContext, useState } from 'react';
-import type { SideEditorConfig } from '@rise4fun/docusaurus-theme-side-editor';
+import type { SideEditorConfig } from '@microsoft/docusaurus-theme-side-editor';
 import useSideEditorConfig from './useSideEditorConfig';
 
 export interface SideEditorSource {

--- a/packages/docusaurus-theme-side-editor/src/client/useSideEditorConfig.ts
+++ b/packages/docusaurus-theme-side-editor/src/client/useSideEditorConfig.ts
@@ -1,4 +1,4 @@
-import type { ThemeConfig } from '@rise4fun/docusaurus-theme-side-editor';
+import type { ThemeConfig } from '@microsoft/docusaurus-theme-side-editor';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 export default function useSideEditorConfig() {

--- a/packages/docusaurus-theme-side-editor/src/index.ts
+++ b/packages/docusaurus-theme-side-editor/src/index.ts
@@ -1,12 +1,12 @@
 import type { Plugin } from '@docusaurus/types';
-import type { ThemeConfig, SideEditorThemeConfig } from '@rise4fun/docusaurus-theme-side-editor';
+import type { ThemeConfig, SideEditorThemeConfig } from '@microsoft/docusaurus-theme-side-editor';
 import validatePeerDependencies from 'validate-peer-dependencies';
 
 validatePeerDependencies(__dirname);
 
 export default function themeSideEditor(): Plugin<void> {
   return {
-    name: '@rise4fun/docusaurus-theme-side-editor',
+    name: '@microsoft/docusaurus-theme-side-editor',
 
     getThemePath() {
       return '../lib/theme';

--- a/packages/docusaurus-theme-side-editor/src/theme-side-editor.ts
+++ b/packages/docusaurus-theme-side-editor/src/theme-side-editor.ts
@@ -1,6 +1,6 @@
 /// <reference types="@docusaurus/module-type-aliases" />
 
-declare module '@rise4fun/docusaurus-theme-side-editor' {
+declare module '@microsoft/docusaurus-theme-side-editor' {
   export type ThemeConfig = {
     sideEditor: SideEditorThemeConfig;
   };
@@ -42,7 +42,7 @@ declare module '@theme/SideEditorRoot' {
 }
 
 declare module '@theme/IFrameEditor' {
-  import type { IFrameEditorConfig } from '@rise4fun/docusaurus-theme-side-editor';
+  import type { IFrameEditorConfig } from '@microsoft/docusaurus-theme-side-editor';
   export interface Props {
     source?: { text?: string };
     config: IFrameEditorConfig;

--- a/website/docs/getting-started/index.mdx
+++ b/website/docs/getting-started/index.mdx
@@ -43,17 +43,17 @@ Let's work on the docusaurus website folder.
 cd website
 ```
 
-Install the [rise4fun plugin](https://www.npmjs.com/package/@rise4fun/docusaurus-plugin-rise4fun)
+Install the [rise4fun plugin](https://www.npmjs.com/package/@microsoft/docusaurus-plugin-rise4fun)
 
 ```bash
-yarn add @rise4fun/docusaurus-plugin-rise4fun
+yarn add @microsoft/docusaurus-plugin-rise4fun
 ```
 
 Open `./docusaurus.config.js` and update it as follows.
 
 ```js title="./docusaurus.config.js"
 // highlight-next-line
-const { configure } = require("@rise4fun/docusaurus-plugin-rise4fun");
+const { configure } = require("@microsoft/docusaurus-plugin-rise4fun");
 ...
 // highlight-next-line
 const config = configure(
@@ -81,7 +81,7 @@ The default Docusaurus template comes with a lot of content. Make sure to give a
 Microsoft projects: make sure that `organizationName` is set to `microsoft`, to enable automatic legal footer injection
 
 ```js title="website/docusaurus.config.js"
-const { configure } = require("@rise4fun/docusaurus-plugin-rise4fun");
+const { configure } = require("@microsoft/docusaurus-plugin-rise4fun");
 ...
 const config = configure(
     {

--- a/website/docs/getting-started/maintenance.mdx
+++ b/website/docs/getting-started/maintenance.mdx
@@ -14,7 +14,7 @@ on how to [migrate versions](https://docusaurus.io/docs/migration).
 
 ## Upgrading rise4fun plugins
 
-You can use **yarn** to upgrade the reference to `@rise4fun/docusaurus-plugin-rise4fun` to the latest released version.
+You can use **yarn** to upgrade the reference to `@microsoft/docusaurus-plugin-rise4fun` to the latest released version.
 
 If you haven't yet, install `npm-check-updates` (`ncu`),
 
@@ -22,10 +22,10 @@ If you haven't yet, install `npm-check-updates` (`ncu`),
 npm install -g npm-check-updates
 ```
 
-Run the update script to upgrade @rise4fun dependencies.
+Run the update script to upgrade @microsoft dependencies.
 
 ```bash
-ncu -u --filter @rise4fun/*
+ncu -u --filter @microsoft/*
 rm yarn.lock
 yarn install
 ```

--- a/website/docs/plugins/docusaurus-plugin-application-insights.mdx
+++ b/website/docs/plugins/docusaurus-plugin-application-insights.mdx
@@ -13,7 +13,7 @@ This plugin is only active in production mode.
 Install the plugin
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-plugin-application-insights
+npm install @microsoft/docusaurus-plugin-application-insights
 ```
 
 Add the plugin to your plugin list along with the [application-insights-web configuration](https://github.com/microsoft/ApplicationInsights-JS#snippet-configuration-options) object.
@@ -23,7 +23,7 @@ const config = {
     plugins: [
         ...,
         // highlight-start
-        ["@rise4fun/docusaurus-plugin-application-insights", {
+        ["@microsoft/docusaurus-plugin-application-insights", {
             instrumentationKey: "YOUR INSTRUMENTATION KEY HERE"
         }]
         // highlight-end

--- a/website/docs/plugins/docusaurus-plugin-rise4fun.mdx
+++ b/website/docs/plugins/docusaurus-plugin-rise4fun.mdx
@@ -11,5 +11,5 @@ This plugin configures all the rise4fun plugins. See the [getting started](/docs
 Install the plugin
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-plugin-rise4fun
+npm install @microsoft/docusaurus-plugin-rise4fun
 ```

--- a/website/docs/plugins/docusaurus-remark-plugin-code-element.mdx
+++ b/website/docs/plugins/docusaurus-remark-plugin-code-element.mdx
@@ -32,7 +32,7 @@ Read the [Code Element documentation](/docs/markdown-features/code-element).
 Install the plugin
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-remark-plugin-code-element
+npm install @microsoft/docusaurus-remark-plugin-code-element
 ```
 
 and add to your `docusaurus.configuration.js` file as other remark plugins.
@@ -42,7 +42,7 @@ const config = {
     plugins: [
         ...,
         // highlight-start
-        ["@rise4fun/docusaurus-remark-code-element", {
+        ["@microsoft/docusaurus-remark-code-element", {
             langs: [{
                 lang: 'cow',
                 element: 'Cow'

--- a/website/docs/plugins/docusaurus-remark-plugin-code-tabs.mdx
+++ b/website/docs/plugins/docusaurus-remark-plugin-code-tabs.mdx
@@ -16,7 +16,7 @@ Read the [Code Tabs documentation](/docs/markdown-features/code-tabs).
 Install the plugin
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-remark-code-tabs
+npm install @microsoft/docusaurus-remark-code-tabs
 ```
 
 and add to your `docusaurus.configuration.js` file as other remark plugins.
@@ -26,7 +26,7 @@ const config = {
     plugins: [
         ...,
         // highlight-start
-        "@rise4fun/docusaurus-remark-code-tabs"
+        "@microsoft/docusaurus-remark-code-tabs"
         // highlight-end
     ]
 }

--- a/website/docs/plugins/docusaurus-remark-plugin-import-file.mdx
+++ b/website/docs/plugins/docusaurus-remark-plugin-import-file.mdx
@@ -15,7 +15,7 @@ Read the [Import file documentation](/docs/markdown-features/import-file).
 Install the plugin
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-remark-import-file
+npm install @microsoft/docusaurus-remark-import-file
 ```
 
 and add to your `docusaurus.configuration.js` file as other remark plugins.
@@ -25,7 +25,7 @@ const config = {
     plugins: [
         ...,
         // highlight-start
-        "@rise4fun/docusaurus-remark-import-file"
+        "@microsoft/docusaurus-remark-import-file"
         // highlight-end
     ]
 }

--- a/website/docs/plugins/docusaurus-remark-plugin-side-editor.mdx
+++ b/website/docs/plugins/docusaurus-remark-plugin-side-editor.mdx
@@ -31,7 +31,7 @@ Read the [Side Editor documentation](/docs/markdown-features/side-editor).
 Install the [side editor theme](./docusaurus-theme-side-editor), then install the remark plugin
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-remark-side-editor
+npm install @microsoft/docusaurus-remark-side-editor
 ```
 
 and add to your `docusaurus.configuration.js` file as other remark plugins.
@@ -41,7 +41,7 @@ const config = {
     plugins: [
         ...,
         // highlight-start
-        ["@rise4fun/docusaurus-remark-side-editor", {
+        ["@microsoft/docusaurus-remark-side-editor", {
 
         }]
         // highlight-end

--- a/website/docs/plugins/docusaurus-theme-codesandbox-button.mdx
+++ b/website/docs/plugins/docusaurus-theme-codesandbox-button.mdx
@@ -14,7 +14,7 @@ A Docusaurus theme component that displays a button to create/open a CodeSandbox
 Install the theme
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-theme-codesandbox-button
+npm install @microsoft/docusaurus-theme-codesandbox-button
 ```
 
 Add the theme to your theme list.
@@ -50,7 +50,7 @@ const config = {
     }
     plugins: [
         // highlight-start
-        "@rise4fun/docusaurus-theme-codesandbox-button"
+        "@microsoft/docusaurus-theme-codesandbox-button"
         // highlight-end
     ]
 }

--- a/website/docs/plugins/docusaurus-theme-side-editor.mdx
+++ b/website/docs/plugins/docusaurus-theme-side-editor.mdx
@@ -34,7 +34,7 @@ Then use the `SideEditorButton` element in your page.
 Install the theme
 
 ```bash npm2yarn
-npm install @rise4fun/docusaurus-theme-side-editor
+npm install @microsoft/docusaurus-theme-side-editor
 ```
 
 Add the theme to your theme list.
@@ -43,7 +43,7 @@ Add the theme to your theme list.
 const config = {
   plugins: [
     // highlight-start
-    ['@rise4fun/docusaurus-theme-side-editor', {}],
+    ['@microsoft/docusaurus-theme-side-editor', {}],
     // highlight-end
   ],
 };

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,7 +4,7 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
-const { configure } = require('@rise4fun/docusaurus-plugin-rise4fun');
+const { configure } = require('@microsoft/docusaurus-plugin-rise4fun');
 const { say } = require('cowsay');
 
 const config = configure(

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "^1.6.22",
     "@msagl/parser": "^1.1.10",
     "@msagl/renderer-svg": "^1.1.10",
-    "@rise4fun/docusaurus-plugin-rise4fun": "^3.0.0",
+    "@microsoft/docusaurus-plugin-rise4fun": "^3.0.0",
     "clsx": "^1.2.1",
     "cowsay": "^1.5.0",
     "msagl-js": "^1.1.10",


### PR DESCRIPTION
## Summary

As the title suggests, we're renaming the package scopes to publish under the official `@microsoft` scope.
